### PR TITLE
Improved the importance() function, adding another method to compute it

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.11" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/pudu_jon.iml
+++ b/.idea/pudu_jon.iml
@@ -2,7 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.11" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/pudu/standards.py
+++ b/pudu/standards.py
@@ -86,3 +86,32 @@ def params_std(y, sh, scope, window, padding, evolution):
     total = sec_row*sec_col
 
     return scope, window, padding, evolution, total
+
+
+def subtract_from_index(vector, index):
+    """
+    This function substract the value of the index to all the vector values.
+
+    :type vector: numpy array
+    :param vector: Vector (or array 1d)
+
+    :type index: int
+    :param index: Index of the substracted value
+
+    :rtype: numpy array
+    :returns: Vector (or array 1d) with the substracted result
+    """
+    # Convert p0 to a numpy array of floats (in case it's not already)
+    vector = np.array(vector, dtype=float)
+
+    # Check that the index is within the valid range
+    if index < 0 or index >= len(vector):
+        raise IndexError("The index is out of bounds")
+
+    # Get the value at the selected index
+    value = vector[index]
+
+    # Subtract the value at the selected index from all other elements
+    result = vector - value
+
+    return result


### PR DESCRIPTION
Improved the importance() function, adding another method to compute it. Added an input variable: method = '1class' (for the previous method) or 'comb_classes' (for the new method). The default method is '1class'. Created a little function (subtract_from_index()) in the standard.py script to be used in the computation of the new method.
The 'comb_classes' method consists in see how the differences between class probabilities change and keep only the dominant term.